### PR TITLE
feat: Reload page after stock movement

### DIFF
--- a/silma-front/src/pages/StockMovement.tsx
+++ b/silma-front/src/pages/StockMovement.tsx
@@ -77,6 +77,7 @@ function Row(props: RowProps) {
    }
     
     setIsEditing(false);
+    window.location.reload();
    }
   return (
     <React.Fragment>


### PR DESCRIPTION
After pressing the button 'Done', the page automatically reloads and shows the storage updated.

![image](https://github.com/gpaez-ol/silma/assets/37886408/8419a2ab-e7db-4487-8554-e97d1f8945ba)
