### PR TITLE
fix: Max length for add order

### DIFF
--- a/silma-front/src/components/PopupInOrder.tsx
+++ b/silma-front/src/components/PopupInOrder.tsx
@@ -157,12 +157,13 @@ export default function PopupInOrder(classes: any) {
                 </Form.Group>
 
                 <Form.Group as={Col} controlId="formGridCity" >
-                  <Row><Form.Label>Notas</Form.Label></Row>
+                  <Row><Form.Label>Notas (Máximo 255 carácteres)</Form.Label></Row>
                   <Row>
                   <textarea 
                     className={classes.textspace}
                     rows={3}
                     value={notes}
+                    maxLength={255}
                     onChange={(event:ChangeEvent<HTMLTextAreaElement>)=> {
                       setNotes(event.target.value)
                     }}


### PR DESCRIPTION
Limits length of Notes field to a max length of 255 characters. If the user tries to keep writing, the field doesn't allow him.

![image](https://github.com/gpaez-ol/silma/assets/37886408/61919a8c-294a-46c1-a8c0-469a8b27b06d)
